### PR TITLE
Fix permissions

### DIFF
--- a/pkg/main/config.go
+++ b/pkg/main/config.go
@@ -393,7 +393,7 @@ func configureApp() (*app, error) {
 
 		// CW_CLIENT_KEY_PERM
 		keyPerm := os.Getenv(prefix + "KEY_PERM")
-		keyPermInt, err := strconv.ParseInt(keyPerm, 0, 0)
+		keyPermInt, err := strconv.ParseInt(keyPerm, 8, 32)
 		if keyPerm == "" || err != nil {
 			app.logger.Debugf("%sKEY_PERM not specified or invalid, using default \"%o\"", prefix, defaultKeyPermissions)
 			cert.KeyPermissions = defaultKeyPermissions
@@ -404,7 +404,7 @@ func configureApp() (*app, error) {
 
 		// CW_CLIENT_CERT_PERM
 		certPerm := os.Getenv(prefix + "CERT_PERM")
-		certPermInt, err := strconv.ParseInt(certPerm, 0, 0)
+		certPermInt, err := strconv.ParseInt(certPerm, 8, 32)
 		if certPerm == "" || err != nil {
 			app.logger.Debugf("%sCERT_PERM not specified, using default \"%o\"", prefix, defaultCertPermissions)
 			cert.CertPermissions = defaultCertPermissions


### PR DESCRIPTION
This pull request improves the handling of file permissions for certificate and key files in the application, ensuring permissions are set correctly and consistently. The changes primarily affect how permissions are parsed from environment variables and how file permissions are applied during file creation and updates.

**File Permission Handling Improvements**

* Changed the parsing of `KEY_PERM` and `CERT_PERM` environment variables to use base 8 (octal) and a 32-bit integer size for correct permission values in `pkg/main/config.go`. [[1]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dL396-R396) [[2]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dL407-R407)

**Explicit Permission Setting After File Writes**

* Updated the logic in `updateCertFilesAndRestartContainers` (in `pkg/main/update_common.go`) to explicitly set file permissions using `os.Chmod` after writing key, certificate, and PFX files. This ensures permissions are correctly applied, even if the underlying OS or filesystem does not honor the permissions set during file creation. [[1]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL98-R134) [[2]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL133-R167) [[3]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL153-R195)
* Enhanced logging to include the permissions used when writing files, improving traceability and debugging. [[1]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL98-R134) [[2]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL133-R167) [[3]](diffhunk://#diff-80e38eac720f1070c39d307b6fe86c7758b70e57a314b73026684fafa7d7c93cL153-R195)