### PR TITLE
Polling interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION
 WORKDIR /
 
 RUN apk add git && \
-    git clone --depth 1 --branch "${VERSION}" https://github.com/gregtwallace/certwarden-client.git /src && \
+    git clone --depth 1 --branch "${VERSION}" https://github.com/Dimariqe/certwarden-client.git /src && \
     cd /src && \
     go build -o ./certwarden-client ./pkg/main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION
 WORKDIR /
 
 RUN apk add git && \
-    git clone --depth 1 --branch "${VERSION}" https://github.com/Dimariqe/certwarden-client.git /src && \
+    git clone --depth 1 --branch "${VERSION}" https://github.com/gregtwallace/certwarden-client.git /src && \
     cd /src && \
     go build -o ./certwarden-client ./pkg/main
 

--- a/pkg/main/config_time_parse.go
+++ b/pkg/main/config_time_parse.go
@@ -100,3 +100,29 @@ func timeAIsAfterOrEqualB(aHr, aMin, bHr, bMin int) bool {
 
 	return false
 }
+
+// parseDurationString parses a duration string like "1d", "5h", "30m" and returns
+// a time.Duration. Supported units: d (days), h (hours), m (minutes), s (seconds)
+func parseDurationString(durationStr string) (time.Duration, error) {
+	if durationStr == "" {
+		return 0, errors.New("duration string is empty")
+	}
+
+	// check for standard Go duration format first (supports combinations like "1h30m")
+	duration, err := time.ParseDuration(durationStr)
+	if err == nil {
+		return duration, nil
+	}
+
+	// if standard parsing fails, try custom day format
+	if strings.HasSuffix(durationStr, "d") {
+		daysStr := strings.TrimSuffix(durationStr, "d")
+		days, err := strconv.Atoi(daysStr)
+		if err != nil || days <= 0 {
+			return 0, errors.New("invalid duration format (use formats like: 1d, 5h, 30m, 1h30m)")
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+
+	return 0, errors.New("invalid duration format (use formats like: 1d, 5h, 30m, 1h30m)")
+}

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -47,6 +47,11 @@ func main() {
 			// failed to get newest cert, so schedule future fetch and write
 			app.scheduleJobFetchCertsAndWriteToDisk(certIndex)
 		}
+
+		// if polling is enabled, start polling job
+		if app.cfg.PollingInterval > 0 {
+			app.scheduleJobPollingFetch(certIndex)
+		}
 	}
 
 	// start https server


### PR DESCRIPTION
This pull request adds support for polling the server for new certificates at a configurable interval, as an alternative to server push notifications. It introduces a new environment variable to control polling, implements duration parsing, updates configuration, and adds background job scheduling for polling.

**Polling support for certificate updates:**

* Added support for the `CW_CLIENT_POLLING_INTERVAL` environment variable, allowing users to specify how frequently the client should poll the server for new certificates (e.g., "1d", "5h", "30m"). If not set, polling is disabled and server push notifications are used instead. (`pkg/main/config.go`, `[[1]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dR47-R48)`, `[[2]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dR156)`, `[[3]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dR211-R226)`)
* Implemented the `parseDurationString` function to parse duration strings with support for days, hours, minutes, and seconds (e.g., "1d", "1h30m"). (`pkg/main/config_time_parse.go`, `[pkg/main/config_time_parse.goR103-R128](diffhunk://#diff-443cdb4932b63113751948cc6207da70f81d9e0af7d6d746af116fb13f763ad0R103-R128)`)

**Background job scheduling for polling:**

* Added the `scheduleJobPollingFetch` method, which starts a background job per certificate that polls the server at the configured interval to check for updates. This job handles cancellation, error logging, and ensures certificate files are updated as needed. (`pkg/main/update_schedule.go`, `[pkg/main/update_schedule.goR200-R248](diffhunk://#diff-961ba96852948a1bde8e27197a7c2b261239693a7a266d8310047141d6d4b39cR200-R248)`)
* Updated the `main` function to start the polling job for each certificate if polling is enabled. (`pkg/main/main.go`, `[pkg/main/main.goR50-R54](diffhunk://#diff-d7a2d96fc0a53ace9214a64c52a292858dcb6abbda3638fccec29d65c2d1f3d4R50-R54)`)