### PR TITLE
Add support for executing commands in Docker containers

### DIFF
--- a/pkg/main/config.go
+++ b/pkg/main/config.go
@@ -56,6 +56,9 @@ import (
 //			CW_CLIENT_0_RESTART_DOCKER_CONTAINER2 ... etc.
 //				Note: Restart is based on file update, so use the vars above to set a file update time window and day(s) of week
 //			CW_CLIENT_0_RESTART_DOCKER_STOP_ONLY	- if 'true' docker containers will be stopped instead of restarted (this is useful if another process like systemctl will start them back up)
+//    	CW_CLIENT_0_COMMAND_DOCKER_CONTAINER0 - execute command in container after cert update, format: "container_name:command arg1 arg2" (e.g., "nginx:nginx -s reload")
+//    	CW_CLIENT_0_COMMAND_DOCKER_CONTAINER1 - another container command (keep adding 1 to the number for more)
+//			CW_CLIENT_0_COMMAND_DOCKER_CONTAINER2 ... etc.
 
 // 			CW_CLIENT_0_CERT_PATH								- the path to save all keys and certificates to
 // 			CW_CLIENT_0_KEY_PEM_FILENAME				- filename to save the key pem as (default is key0.pem ; number == index)
@@ -118,6 +121,12 @@ type app struct {
 	cipherAEAD        []cipher.AEAD
 }
 
+// containerCommand holds a container name and command to execute
+type containerCommand struct {
+	ContainerName string
+	Command       []string
+}
+
 // certConfig contains all of the configuration specific to
 // a given certificate
 type certConfig struct {
@@ -128,6 +137,7 @@ type certConfig struct {
 	FileUpdateTimeIncludesMidnight bool
 	FileUpdateDaysOfWeek           map[time.Weekday]struct{}
 	DockerContainersToRestart      []string
+	DockerContainerCommands        []containerCommand
 	DockerStopOnly                 bool
 	KeyName                        string
 	KeyApiKey                      string
@@ -326,21 +336,55 @@ func configureApp() (*app, error) {
 			cert.DockerContainersToRestart = append(cert.DockerContainersToRestart, containerName)
 		}
 
+		// CW_CLIENT_COMMAND_DOCKER_CONTAINER (0... etc.)
+		// Format: "container_name:command arg1 arg2"
+		cert.DockerContainerCommands = []containerCommand{}
+		for i := 0; true; i++ {
+			commandStr := os.Getenv(prefix + "COMMAND_DOCKER_CONTAINER" + strconv.Itoa(i))
+			if commandStr == "" {
+				// if next number not specified, done
+				break
+			}
+
+			// Parse format: "container_name:command arg1 arg2"
+			parts := strings.SplitN(commandStr, ":", 2)
+			if len(parts) != 2 {
+				app.logger.Errorf("%sCOMMAND_DOCKER_CONTAINER%d has invalid format (expected 'container:command'), skipping", prefix, i)
+				continue
+			}
+
+			containerName := strings.TrimSpace(parts[0])
+			commandPart := strings.TrimSpace(parts[1])
+
+			if containerName == "" || commandPart == "" {
+				app.logger.Errorf("%sCOMMAND_DOCKER_CONTAINER%d has empty container name or command, skipping", prefix, i)
+				continue
+			}
+
+			// Split command into parts (space-separated)
+			commandArgs := strings.Fields(commandPart)
+
+			cert.DockerContainerCommands = append(cert.DockerContainerCommands, containerCommand{
+				ContainerName: containerName,
+				Command:       commandArgs,
+			})
+		}
+
 		// ensure this only happens once -- app has one common api client
-		if len(cert.DockerContainersToRestart) > 0 && app.dockerAPIClient == nil {
+		if (len(cert.DockerContainersToRestart) > 0 || len(cert.DockerContainerCommands) > 0) && app.dockerAPIClient == nil {
 			app.dockerAPIClient, err = dockerClient.NewClientWithOpts(
 				dockerClient.FromEnv,
 				dockerClient.WithAPIVersionNegotiation(),
 			)
 			if err != nil {
-				return app, fmt.Errorf("specified %sRESTART_DOCKER_CONTAINER but couldn't make docker api client (%s)", prefix, err)
+				return app, fmt.Errorf("specified %sRESTART_DOCKER_CONTAINER or %sCOMMAND_DOCKER_CONTAINER but couldn't make docker api client (%s)", prefix, prefix, err)
 			}
 
 			testPingCtx, cancelPing := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancelPing()
 			_, err := app.dockerAPIClient.Ping(testPingCtx)
 			if err != nil {
-				app.logger.Errorf("specified %sRESTART_DOCKER_CONTAINER but couldn't connect to docker api (%s), verify access to docker or restarts will not occur", prefix, err)
+				app.logger.Errorf("specified %sRESTART_DOCKER_CONTAINER or %sCOMMAND_DOCKER_CONTAINER but couldn't connect to docker api (%s), verify access to docker or operations will not occur", prefix, prefix, err)
 			}
 		}
 

--- a/pkg/main/docker.go
+++ b/pkg/main/docker.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"io"
+	"strings"
 	"time"
 
 	dockerContainerTypes "github.com/docker/docker/api/types/container"
@@ -9,6 +11,7 @@ import (
 
 const dockerRestartContextTimeout = 3 * time.Minute
 const dockerGracefulExitTimeoutSeconds = 60
+const dockerExecContextTimeout = 2 * time.Minute
 
 // restartOrStopDockerContainers stops or restarts each of the container names specified in the
 // config file; this func is called after cert files are updated; restarts/stops are done
@@ -47,5 +50,83 @@ func (app *app) restartOrStopDockerContainers(certIndex int) {
 			}
 
 		}(container)
+	}
+}
+
+// executeDockerContainerCommands executes commands in specified Docker containers
+// after cert files are updated; executions are done async and results are logged
+func (app *app) executeDockerContainerCommands(certIndex int) {
+	app.logger.Infof("executing docker container command(s) for cert %d", certIndex)
+
+	// abort if invalid index
+	if certIndex > len(app.cfg.Certs) {
+		app.logger.Errorf("docker command execution failed, invalid cert index %d (how'd that happen??)", certIndex)
+		return
+	}
+
+	for _, containerCmd := range app.cfg.Certs[certIndex].DockerContainerCommands {
+		go func(asyncContainerCmd containerCommand) {
+			execCtx, cancel := context.WithTimeout(context.Background(), dockerExecContextTimeout)
+			defer cancel()
+
+			// Create exec configuration
+			execConfig := dockerContainerTypes.ExecOptions{
+				AttachStdout: true,
+				AttachStderr: true,
+				Cmd:          asyncContainerCmd.Command,
+			}
+
+			// Create exec instance
+			execID, err := app.dockerAPIClient.ContainerExecCreate(execCtx, asyncContainerCmd.ContainerName, execConfig)
+			if err != nil {
+				app.logger.Errorf("failed to create exec for container %s command %v (%s)",
+					asyncContainerCmd.ContainerName, asyncContainerCmd.Command, err)
+				return
+			}
+
+			// Start exec
+			execStartCheck := dockerContainerTypes.ExecStartOptions{
+				Detach: false,
+				Tty:    false,
+			}
+
+			resp, err := app.dockerAPIClient.ContainerExecAttach(execCtx, execID.ID, execStartCheck)
+			if err != nil {
+				app.logger.Errorf("failed to attach exec for container %s command %v (%s)",
+					asyncContainerCmd.ContainerName, asyncContainerCmd.Command, err)
+				return
+			}
+			defer resp.Close()
+
+			// Read output
+			output, err := io.ReadAll(resp.Reader)
+			if err != nil {
+				app.logger.Errorf("failed to read exec output for container %s command %v (%s)",
+					asyncContainerCmd.ContainerName, asyncContainerCmd.Command, err)
+			}
+
+			// Check exit code
+			inspectResp, err := app.dockerAPIClient.ContainerExecInspect(execCtx, execID.ID)
+			if err != nil {
+				app.logger.Errorf("failed to inspect exec for container %s command %v (%s)",
+					asyncContainerCmd.ContainerName, asyncContainerCmd.Command, err)
+				return
+			}
+
+			if inspectResp.ExitCode == 0 {
+				outputStr := strings.TrimSpace(string(output))
+				if outputStr != "" {
+					app.logger.Infof("successfully executed command in container %s: %v (output: %s)",
+						asyncContainerCmd.ContainerName, asyncContainerCmd.Command, outputStr)
+				} else {
+					app.logger.Infof("successfully executed command in container %s: %v",
+						asyncContainerCmd.ContainerName, asyncContainerCmd.Command)
+				}
+			} else {
+				app.logger.Errorf("command failed in container %s: %v (exit code: %d, output: %s)",
+					asyncContainerCmd.ContainerName, asyncContainerCmd.Command, inspectResp.ExitCode, strings.TrimSpace(string(output)))
+			}
+
+		}(containerCmd)
 	}
 }

--- a/pkg/main/update_common.go
+++ b/pkg/main/update_common.go
@@ -172,6 +172,16 @@ func (app *app) updateCertFilesAndRestartContainers(certIndex int, onlyIfMissing
 		}
 	}
 
+	// execute commands in docker containers (if any files written)
+	if len(app.cfg.Certs[certIndex].DockerContainerCommands) > 0 {
+		if wroteAnyFiles {
+			app.logger.Infof("at least one file changed for cert %d, executing docker container commands", certIndex)
+			app.executeDockerContainerCommands(certIndex)
+		} else {
+			app.logger.Debugf("not executing docker container commands for cert %d, no changes were written to disk", certIndex)
+		}
+	}
+
 	// log result
 	diskNeedsUpdate = false
 	if failedAnyWrite {


### PR DESCRIPTION
This pull request adds support for executing custom commands inside Docker containers after certificate files are updated. It introduces new configuration options, updates the configuration parsing logic, and implements the command execution workflow, including error handling and logging.

**Docker container command execution support:**

* Added new environment variable options (`CW_CLIENT_0_COMMAND_DOCKER_CONTAINER0`, etc.) to specify commands to run inside containers after cert updates, with format `"container_name:command arg1 arg2"`.
* Introduced a new `containerCommand` type and updated the `certConfig` struct to include a list of container commands (`DockerContainerCommands`). [[1]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dR124-R129) [[2]](diffhunk://#diff-27bb5023dd4d98c7ac3f60d9c3b3a37e9ce4a6beba4bd9ce45647a44d236d01dR140)
* Updated the configuration loader to parse the new container command environment variables, validate their format, and store them in the config. Docker API client initialization now also considers these commands.

**Implementation of command execution:**

* Added the `executeDockerContainerCommands` method to asynchronously execute specified commands inside containers, log output, and handle errors and exit codes.
* Integrated command execution into the certificate update workflow, so commands are only run when files are actually changed.